### PR TITLE
Fix: RAM Sparkline max value

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -294,7 +294,7 @@ impl App {
           .block(block)
           .direction(RenderDirection::RightToLeft)
           .data(&val.items)
-          .max(val.max_ram)
+          .max(val.ram_total)
           .style(self.cfg.color);
         f.render_widget(w, r);
       }


### PR DESCRIPTION
`.max(val.max_ram)` changed to `.max(val.ram_total)` fixes #7 

![image](https://github.com/user-attachments/assets/f078aefc-01d1-4e2a-925b-20a4b7d3ca53)
