### PR TITLE
chore: improve robustness of `print_debug` by handling missing system profiler keys

### DIFF
--- a/src/debug.rs
+++ b/src/debug.rs
@@ -20,10 +20,16 @@ fn print_divider(msg: &str) {
 pub fn print_debug() -> WithError<()> {
   let out = run_system_profiler()?;
 
-  let chip = out["SPHardwareDataType"][0]["chip_type"].as_str().unwrap().to_string();
-  let model = out["SPHardwareDataType"][0]["machine_model"].as_str().unwrap().to_string();
-  let os_ver = out["SPSoftwareDataType"][0]["os_version"].as_str().unwrap().to_string();
-  let procs = out["SPHardwareDataType"][0]["number_processors"].as_str().unwrap().to_string();
+  let chip =
+    out["SPHardwareDataType"][0]["chip_type"].as_str().unwrap_or("Unknown chip").to_string();
+  let model =
+    out["SPHardwareDataType"][0]["machine_model"].as_str().unwrap_or("Unknown model").to_string();
+  let os_ver =
+    out["SPSoftwareDataType"][0]["os_version"].as_str().unwrap_or("Unknown OS version").to_string();
+  let procs = out["SPHardwareDataType"][0]["number_processors"]
+    .as_str()
+    .unwrap_or("Unknown processors")
+    .to_string();
   println!("Chip: {} | Model: {} | OS: {} | {}", chip, model, os_ver, procs);
 
   print_divider("AppleARMIODevice");


### PR DESCRIPTION
seeing some crash in CI, add some fallback for system profile checks

```
==> /opt/homebrew/Cellar/macmon/0.4.0/bin/macmon debug
thread 'main' panicked at src/debug.rs:26:74:
called `Option::unwrap()` on a `None` value
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

and now it would be 

```
==> /opt/homebrew/Cellar/macmon/0.4.0/bin/macmon debug
Error: "Failed to get channels"
Chip: Apple M1 (Virtual) | Model: VirtualMac2,1 | OS: macOS 15.1.1 (24B91) | Unknown processors

--- AppleARMIODevice -----------------------------------------------------------

--- IOReport -------------------------------------------------------------------
/opt/homebrew/Library/Homebrew/ignorable.rb:27:in `block in raise'
Minitest::Assertion: Expected: 0
  Actual: 1
```

relates to https://github.com/Homebrew/homebrew-core/pull/200767/