### PR TITLE
feat: add Apple M5 chip support

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -240,6 +240,7 @@ pub struct App {
 
   ecpu_freq: FreqStore,
   pcpu_freq: FreqStore,
+  mcpu_freq: FreqStore,
   igpu_freq: FreqStore,
 }
 
@@ -258,6 +259,7 @@ impl App {
     self.sys_power.push(data.sys_power as f64);
     self.ecpu_freq.push(data.ecpu_usage.0 as u64, data.ecpu_usage.1 as f64);
     self.pcpu_freq.push(data.pcpu_usage.0 as u64, data.pcpu_usage.1 as f64);
+    self.mcpu_freq.push(data.mcpu_usage.0 as u64, data.mcpu_usage.1 as f64);
     self.igpu_freq.push(data.gpu_usage.0 as u64, data.gpu_usage.1 as f64);
 
     self.cpu_temp.push(data.temp.cpu_temp_avg);
@@ -365,14 +367,25 @@ impl App {
   }
 
   fn render(&mut self, f: &mut Frame) {
-    let label_l = format!(
-      "{} ({}E+{}P+{}GPU {}GB)",
-      self.soc.chip_name,
-      self.soc.ecpu_cores,
-      self.soc.pcpu_cores,
-      self.soc.gpu_cores,
-      self.soc.memory_gb,
-    );
+    let label_l = if self.soc.has_mcpu() {
+      format!(
+        "{} ({}M+{}S+{}GPU {}GB)",
+        self.soc.chip_name,
+        self.soc.mcpu_cores,
+        self.soc.pcpu_cores,
+        self.soc.gpu_cores,
+        self.soc.memory_gb,
+      )
+    } else {
+      format!(
+        "{} ({}E+{}P+{}GPU {}GB)",
+        self.soc.chip_name,
+        self.soc.ecpu_cores,
+        self.soc.pcpu_cores,
+        self.soc.gpu_cores,
+        self.soc.memory_gb,
+      )
+    };
 
     let rows = Layout::default()
       .direction(Direction::Vertical)
@@ -391,8 +404,13 @@ impl App {
 
     // 1st row
     let (c1, c2) = h_stack(iarea[0]);
-    self.render_freq_block(f, c1, "E-CPU", &self.ecpu_freq);
-    self.render_freq_block(f, c2, "P-CPU", &self.pcpu_freq);
+    if self.soc.has_mcpu() {
+      self.render_freq_block(f, c1, "P-CPU", &self.mcpu_freq);
+      self.render_freq_block(f, c2, "S-CPU", &self.pcpu_freq);
+    } else {
+      self.render_freq_block(f, c1, "E-CPU", &self.ecpu_freq);
+      self.render_freq_block(f, c2, "P-CPU", &self.pcpu_freq);
+    }
 
     // 2nd row
     let (c1, c2) = h_stack(iarea[1]);

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -33,6 +33,7 @@ pub struct Metrics {
   pub memory: MemMetrics,
   pub ecpu_usage: (u32, f32), // freq, percent_from_max
   pub pcpu_usage: (u32, f32), // freq, percent_from_max
+  pub mcpu_usage: (u32, f32), // freq, percent_from_max
   pub gpu_usage: (u32, f32),  // freq, percent_from_max
   pub cpu_power: f32,         // Watts
   pub gpu_power: f32,         // Watts
@@ -231,6 +232,7 @@ impl Sampler {
     for (sample, dt) in self.ior.get_samples(duration as u64, measures) {
       let mut ecpu_usages = Vec::new();
       let mut pcpu_usages = Vec::new();
+      let mut mcpu_usages = Vec::new();
       let mut rs = Metrics::default();
 
       for x in sample {
@@ -242,6 +244,11 @@ impl Sampler {
 
           if x.channel.contains("PCPU") {
             pcpu_usages.push(calc_freq(x.item, &self.soc.pcpu_freqs));
+            continue;
+          }
+
+          if x.channel.contains("MCPU") {
+            mcpu_usages.push(calc_freq(x.item, &self.soc.mcpu_freqs));
             continue;
           }
         }
@@ -267,8 +274,15 @@ impl Sampler {
         }
       }
 
-      rs.ecpu_usage = calc_freq_final(&ecpu_usages, &self.soc.ecpu_freqs);
-      rs.pcpu_usage = calc_freq_final(&pcpu_usages, &self.soc.pcpu_freqs);
+      if !self.soc.ecpu_freqs.is_empty() {
+        rs.ecpu_usage = calc_freq_final(&ecpu_usages, &self.soc.ecpu_freqs);
+      }
+      if !self.soc.pcpu_freqs.is_empty() {
+        rs.pcpu_usage = calc_freq_final(&pcpu_usages, &self.soc.pcpu_freqs);
+      }
+      if !self.soc.mcpu_freqs.is_empty() {
+        rs.mcpu_usage = calc_freq_final(&mcpu_usages, &self.soc.mcpu_freqs);
+      }
       results.push(rs);
     }
 
@@ -277,6 +291,8 @@ impl Sampler {
     rs.ecpu_usage.1 = zero_div(results.iter().map(|x| x.ecpu_usage.1).sum(), measures as _);
     rs.pcpu_usage.0 = zero_div(results.iter().map(|x| x.pcpu_usage.0).sum(), measures as _);
     rs.pcpu_usage.1 = zero_div(results.iter().map(|x| x.pcpu_usage.1).sum(), measures as _);
+    rs.mcpu_usage.0 = zero_div(results.iter().map(|x| x.mcpu_usage.0).sum(), measures as _);
+    rs.mcpu_usage.1 = zero_div(results.iter().map(|x| x.mcpu_usage.1).sum(), measures as _);
     rs.gpu_usage.0 = zero_div(results.iter().map(|x| x.gpu_usage.0).sum(), measures as _);
     rs.gpu_usage.1 = zero_div(results.iter().map(|x| x.gpu_usage.1).sum(), measures as _);
     rs.cpu_power = zero_div(results.iter().map(|x| x.cpu_power).sum(), measures as _);

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -389,7 +389,7 @@ impl SocInfo {
     get_soc_info()
   }
 
-  /// Returns true if this is an M5 or later chip with super cores instead of efficiency cores
+  // true if M5+ chip with super cores instead of efficiency cores
   pub fn has_mcpu(&self) -> bool {
     self.mcpu_cores > 0
   }
@@ -433,6 +433,35 @@ fn to_mhz(vals: Vec<u32>, scale: u32) -> Vec<u32> {
   vals.iter().map(|x| *x / scale).collect()
 }
 
+// parse number_processors string into (ecpu_cores, pcpu_cores, mcpu_cores)
+// M1-M4: "proc T:P:E" (3 fields) -> (E, P, 0)
+// M5+:   "proc T:S:E:M" (4 fields) -> (E, S, M)
+fn parse_cpu_cores(number_processors: &str) -> (u64, u64, u64) {
+  let cpu_cores = number_processors
+    .strip_prefix("proc ")
+    .unwrap_or("")
+    .split(':')
+    .map(|x| x.parse::<u64>().unwrap_or(0))
+    .collect::<Vec<_>>();
+
+  match cpu_cores.len() {
+    4 => (cpu_cores[2], cpu_cores[1], cpu_cores[3]), // M5+: total:S:E:M
+    3 => (cpu_cores[2], cpu_cores[1], 0),             // M1-M4: total:P:E
+    _ => (0, 0, 0),
+  }
+}
+
+// M1-M3: MHz scale (1_000_000), M4+: KHz scale (1_000)
+fn cpu_freq_scale(chip_name: &str) -> u32 {
+  let before_m4 =
+    chip_name.contains("M1") || chip_name.contains("M2") || chip_name.contains("M3");
+  if before_m4 { 1000 * 1000 } else { 1000 }
+}
+
+fn is_m5_chip(chip_name: &str) -> bool {
+  chip_name.contains("M5")
+}
+
 pub fn get_soc_info() -> WithError<SocInfo> {
   let out = run_system_profiler()?;
   let mut info = SocInfo::default();
@@ -453,29 +482,18 @@ pub fn get_soc_info() -> WithError<SocInfo> {
     .parse::<u64>()
     .unwrap_or(0);
 
-  // SPHardwareDataType.0.number_processors -> "proc x:y:z"
-  let cpu_cores = out["SPHardwareDataType"][0]["number_processors"]
-    .as_str()
-    .and_then(|cores| cores.strip_prefix("proc "))
-    .unwrap_or("")
-    .split(':')
-    .map(|x| x.parse::<u64>().unwrap_or(0))
-    .collect::<Vec<_>>();
-  // "proc 18:6:0:12" on M5 (total:S:E:M) or "proc 10:4:6" on M1-M4 (total:P:E)
-  let (ecpu_cores, pcpu_cores, mcpu_cores) = match cpu_cores.len() {
-    4 => (cpu_cores[2], cpu_cores[1], cpu_cores[3]), // M5+: total:S:E:M
-    3 => (cpu_cores[2], cpu_cores[1], 0),             // M1-M4: total:P:E
-    _ => (0, 0, 0),
-  };
+  // SPHardwareDataType.0.number_processors -> "proc x:y:z" or "proc w:x:y:z"
+  let number_processors =
+    out["SPHardwareDataType"][0]["number_processors"].as_str().unwrap_or("");
+  let (ecpu_cores, pcpu_cores, mcpu_cores) = parse_cpu_cores(number_processors);
 
   // SPDisplaysDataType.0.sppci_cores
   let gpu_cores =
     out["SPDisplaysDataType"][0]["sppci_cores"].as_str().unwrap_or("0").parse::<u64>().unwrap_or(0);
 
   // Determine scaling based on chip type
-  let is_m5 = chip_name.contains("M5");
-  let before_m4 = chip_name.contains("M1") || chip_name.contains("M2") || chip_name.contains("M3");
-  let cpu_scale: u32 = if before_m4 { 1000 * 1000 } else { 1000 }; // MHz before M4, KHz after
+  let is_m5 = is_m5_chip(&chip_name);
+  let cpu_scale = cpu_freq_scale(&chip_name);
   let gpu_scale: u32 = 1000 * 1000; // MHz
 
   // Assign parsed values to info
@@ -939,5 +957,115 @@ impl Drop for SMC {
     unsafe {
       IOServiceClose(self.conn);
     }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn test_parse_cpu_cores_m1_m4() {
+    // M1 Pro: "proc 10:8:2" -> 2 ecpu, 8 pcpu, 0 mcpu
+    assert_eq!(parse_cpu_cores("proc 10:8:2"), (2, 8, 0));
+    // M4: "proc 10:4:6" -> 6 ecpu, 4 pcpu, 0 mcpu
+    assert_eq!(parse_cpu_cores("proc 10:4:6"), (6, 4, 0));
+    // M3 Max: "proc 16:12:4" -> 4 ecpu, 12 pcpu, 0 mcpu
+    assert_eq!(parse_cpu_cores("proc 16:12:4"), (4, 12, 0));
+  }
+
+  #[test]
+  fn test_parse_cpu_cores_m5() {
+    // M5 Max: "proc 18:6:0:12" -> 0 ecpu, 6 pcpu(super), 12 mcpu(perf)
+    assert_eq!(parse_cpu_cores("proc 18:6:0:12"), (0, 6, 12));
+    // M5 Pro: "proc 14:4:0:10" (hypothetical)
+    assert_eq!(parse_cpu_cores("proc 14:4:0:10"), (0, 4, 10));
+  }
+
+  #[test]
+  fn test_parse_cpu_cores_invalid() {
+    assert_eq!(parse_cpu_cores(""), (0, 0, 0));
+    assert_eq!(parse_cpu_cores("proc"), (0, 0, 0));
+    assert_eq!(parse_cpu_cores("garbage"), (0, 0, 0));
+  }
+
+  #[test]
+  fn test_has_mcpu() {
+    let mut soc = SocInfo::default();
+    assert!(!soc.has_mcpu());
+
+    soc.mcpu_cores = 12;
+    assert!(soc.has_mcpu());
+  }
+
+  #[test]
+  fn test_to_mhz() {
+    // KHz scale (M4/M5): raw values in KHz, divide by 1000 to get MHz
+    assert_eq!(to_mhz(vec![4608000, 3000000], 1000), vec![4608, 3000]);
+    // MHz scale (M1-M3): raw values in Hz, divide by 1_000_000 to get MHz
+    // Use 3_000_000 (3 MHz) as a small representative value that fits in u32
+    assert_eq!(to_mhz(vec![3_000_000, 2_000_000], 1000 * 1000), vec![3, 2]);
+    // Empty input
+    assert_eq!(to_mhz(vec![], 1000), Vec::<u32>::new());
+  }
+
+  // -- is_m5_chip tests --
+
+  #[test]
+  fn test_is_m5_chip() {
+    assert!(is_m5_chip("Apple M5 Max"));
+    assert!(is_m5_chip("Apple M5 Pro"));
+    assert!(is_m5_chip("Apple M5"));
+    assert!(!is_m5_chip("Apple M4 Max"));
+    assert!(!is_m5_chip("Apple M4"));
+    assert!(!is_m5_chip("Apple M3 Pro"));
+    assert!(!is_m5_chip("Apple M1"));
+    assert!(!is_m5_chip("Unknown chip"));
+  }
+
+  // -- cpu_freq_scale tests --
+
+  #[test]
+  fn test_cpu_freq_scale_before_m4() {
+    // M1-M3 use MHz scale (1_000_000)
+    assert_eq!(cpu_freq_scale("Apple M1"), 1_000_000);
+    assert_eq!(cpu_freq_scale("Apple M2 Pro"), 1_000_000);
+    assert_eq!(cpu_freq_scale("Apple M3 Max"), 1_000_000);
+  }
+
+  #[test]
+  fn test_cpu_freq_scale_m4_and_later() {
+    // M4+ use KHz scale (1_000)
+    assert_eq!(cpu_freq_scale("Apple M4"), 1_000);
+    assert_eq!(cpu_freq_scale("Apple M4 Pro"), 1_000);
+    assert_eq!(cpu_freq_scale("Apple M5 Max"), 1_000);
+  }
+
+  // -- SocInfo default state --
+
+  #[test]
+  fn test_soc_info_default_mcpu_fields() {
+    let info = SocInfo::default();
+    assert_eq!(info.mcpu_cores, 0);
+    assert!(info.mcpu_freqs.is_empty());
+    assert!(!info.has_mcpu());
+  }
+
+  // -- parse_cpu_cores edge cases --
+
+  #[test]
+  fn test_parse_cpu_cores_no_proc_prefix() {
+    assert_eq!(parse_cpu_cores("10:8:2"), (0, 0, 0));
+  }
+
+  #[test]
+  fn test_parse_cpu_cores_single_field() {
+    assert_eq!(parse_cpu_cores("proc 8"), (0, 0, 0));
+  }
+
+  #[test]
+  fn test_parse_cpu_cores_five_fields() {
+    // Hypothetical future format with 5 fields -> unknown, fallback
+    assert_eq!(parse_cpu_cores("proc 24:6:0:12:6"), (0, 0, 0));
   }
 }


### PR DESCRIPTION
## Summary

Adds support for Apple M5 Pro/Max chips, which introduce a new core architecture:

- **Super cores (S-CPU, 6)** — highest performance tier, replacing old P-cores. IOReport channels: `PCPU`. DVFS key: `voltage-states5-sram`
- **Performance cores (P-CPU, 12)** — mid-tier, replacing old E-cores. IOReport channels: `MCPU`. DVFS key: `voltage-states22-sram`
- **No efficiency cores** — the M5 drops E-cores entirely

### Changes

- **Fix crash**: `get_dvfs_mhz()` no longer panics when a DVFS key is missing (`voltage-states1-sram` doesn't exist on M5)
- **M5 chip detection**: Detects M5 chips and uses the correct voltage-states key mapping
- **4-field proc format**: Handles `"proc 18:6:0:12"` (total:S:E:M) in addition to the existing 3-field format
- **MCPU metrics pipeline**: Adds `mcpu_cores`, `mcpu_freqs`, and `mcpu_usage` fields throughout `SocInfo`, `Metrics`, and the TUI
- **Updated TUI labels**: Shows "S-CPU" and "P-CPU" on M5 (instead of "E-CPU" and "P-CPU")
- **Unit tests**: Extracts `parse_cpu_cores()` helper and adds tests for M5/M1-M4/invalid input parsing

### Tested on

- MacBook Pro M5 Max (Mac17,7), macOS 26.3.0
- `macmon pipe` output confirms correct metrics:
  - `mcpu_usage: [3632, 0.36]` — 12 M-cores reporting
  - `pcpu_usage: [3982, 0.80]` — 6 super cores reporting
  - `ecpu_usage: [0, 0.0]` — correctly empty
  - GPU, temperature, power, and memory metrics all functional

### Before (crash)
```
thread 'main' panicked at src/sources.rs:394:41:
called `Option::unwrap()` on a `None` value
```

### After
```json
{"mcpu_usage":[3632,0.36],"pcpu_usage":[3982,0.80],"ecpu_usage":[0,0.0],...}
```

### Help wanted: M5 Pro verification

The DVFS voltage-states key numbers are hardcoded based on the M5 Max. These keys may differ on the M5 Pro or base M5. The crash fix means unknown keys won't panic (they gracefully return empty data), but frequency reporting may be missing on untested variants.

To make it robust for all M5 variants, we'd need someone with an M5 Pro to run:

```bash
ioreg -r -d 1 -c AppleARMIODevice -n pmgr | grep -o '"voltage-states[^"]*"' | sort -u
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)