### PR TITLE
fix: discard bogus sensor temp readings

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -190,7 +190,9 @@ impl Sampler {
 
       if name.starts_with("GPU MTR Temp Sensor") {
         // println!("{}: {}", name, value);
-        gpu_values.push(*value);
+        if *value > 0.0 && *value <= 150.0 {
+          gpu_values.push(*value);
+        }
         continue;
       }
     }

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -712,6 +712,9 @@ impl IOHIDSensors {
 
         let temp = IOHIDEventGetFloatValue(event, kIOHIDEventTypeTemperature << 16);
         CFRelease(event as _);
+        if temp <= 0.0 || temp > 150.0 {
+          continue;
+        }
         items.push((name, temp as f32));
       }
 


### PR DESCRIPTION
I have macmon pushing cpu_temp_avg and gpu_temp_avg over to a grafana instance.  I noticed that on both of my M4 Mac Minis, gpu_temp_avg will seemingly randomly read -1.85C multiple times throughout the day.

This patch will discard bogus temperatures.

Screenshot attached.

<img width="1170" height="430" alt="Screenshot 2026-03-13 at 22 45 08" src="https://github.com/user-attachments/assets/29809f9e-37cc-4516-b202-2a82334e467d" />
