### PR TITLE
Cpu usage semantics

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -61,10 +61,14 @@ fn is_active_state(name: &str) -> bool {
 }
 
 fn calc_freq_from_residencies(items: &[(String, i64)], freqs: &[u32]) -> (u32, f32) {
-  let (len1, len2) = (items.len(), freqs.len());
-  assert!(len1 > len2, "cacl_freq invalid data: {} vs {}", len1, len2); // todo?
-
   let offset = items.iter().position(|x| is_active_state(x.0.as_str())).unwrap();
+  assert!(
+    items.len() >= offset + freqs.len(),
+    "calc_freq invalid data: items={}, offset={}, freqs={}",
+    items.len(),
+    offset,
+    freqs.len()
+  );
 
   let usage = items.iter().map(|x| x.1 as f64).skip(offset).sum::<f64>();
   let total = items.iter().map(|x| x.1 as f64).sum::<f64>();
@@ -369,6 +373,14 @@ mod tests {
 
     assert_eq!(freq, 0);
     assert!((usage - 0.5f32).abs() < 1e-6f32);
+  }
+
+  #[test]
+  #[should_panic(expected = "calc_freq invalid data")]
+  fn calc_freq_panics_when_frequency_table_outruns_active_states() {
+    let items = vec![("IDLE".to_string(), 50), ("F1".to_string(), 50)];
+
+    calc_freq_from_residencies(&items, &[1000, 2000]);
   }
 
   #[test]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -89,12 +89,11 @@ fn calc_freq(item: CFDictionaryRef, freqs: &[u32]) -> (u32, f32) {
   calc_freq_from_residencies(&items, freqs)
 }
 
-fn calc_freq_final(items: &[(u32, f32)], freqs: &[u32]) -> (u32, f32) {
+fn calc_cluster_usage(items: &[(u32, f32)]) -> (u32, f32) {
   let avg_freq = zero_div(items.iter().map(|x| x.0 as f32).sum(), items.len() as f32);
   let avg_perc = zero_div(items.iter().map(|x| x.1).sum(), items.len() as f32);
-  let min_freq = *freqs.first().unwrap() as f32;
 
-  (avg_freq.max(min_freq) as u32, avg_perc)
+  (avg_freq as u32, avg_perc)
 }
 
 fn init_smc() -> WithError<(SMC, Vec<String>, Vec<String>)> {
@@ -301,8 +300,8 @@ impl Sampler {
 
       // Filter dead/disabled cores (e.g. M5 Max MCPU0 cluster is all-DOWN)
       ecpu_usages.retain(|&(_, pct)| pct > 0.0);
-      rs.ecpu_usage = calc_freq_final(&ecpu_usages, &self.soc.ecpu_freqs);
-      rs.pcpu_usage = calc_freq_final(&pcpu_usages, &self.soc.pcpu_freqs);
+      rs.ecpu_usage = calc_cluster_usage(&ecpu_usages);
+      rs.pcpu_usage = calc_cluster_usage(&pcpu_usages);
       results.push(rs);
     }
 
@@ -344,7 +343,7 @@ impl Sampler {
 
 #[cfg(test)]
 mod tests {
-  use super::calc_freq_from_residencies;
+  use super::{calc_cluster_usage, calc_freq_from_residencies};
 
   #[test]
   fn calc_freq_returns_raw_usage_ratio() {
@@ -381,6 +380,14 @@ mod tests {
     let items = vec![("IDLE".to_string(), 50), ("F1".to_string(), 50)];
 
     calc_freq_from_residencies(&items, &[1000, 2000]);
+  }
+
+  #[test]
+  fn calc_cluster_usage_preserves_idle_frequency() {
+    let (freq, usage) = calc_cluster_usage(&[(0, 0.0), (0, 0.0)]);
+
+    assert_eq!(freq, 0);
+    assert_eq!(usage, 0.0);
   }
 
   #[test]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -55,13 +55,16 @@ fn is_valid_temp(val: f32) -> bool {
   val > 0.0 && val <= 150.0
 }
 
-fn calc_freq(item: CFDictionaryRef, freqs: &[u32]) -> (u32, f32) {
-  let items = cfio_get_residencies(item); // (ns, freq)
+fn is_active_state(name: &str) -> bool {
+  // IDLE / DOWN for CPU; OFF for GPU; DOWN only on M2?/M3 Max Chips
+  name != "IDLE" && name != "DOWN" && name != "OFF"
+}
+
+fn calc_freq_from_residencies(items: &[(String, i64)], freqs: &[u32]) -> (u32, f32) {
   let (len1, len2) = (items.len(), freqs.len());
   assert!(len1 > len2, "cacl_freq invalid data: {} vs {}", len1, len2); // todo?
 
-  // IDLE / DOWN for CPU; OFF for GPU; DOWN only on M2?/M3 Max Chips
-  let offset = items.iter().position(|x| x.0 != "IDLE" && x.0 != "DOWN" && x.0 != "OFF").unwrap();
+  let offset = items.iter().position(|x| is_active_state(x.0.as_str())).unwrap();
 
   let usage = items.iter().map(|x| x.1 as f64).skip(offset).sum::<f64>();
   let total = items.iter().map(|x| x.1 as f64).sum::<f64>();
@@ -75,6 +78,11 @@ fn calc_freq(item: CFDictionaryRef, freqs: &[u32]) -> (u32, f32) {
 
   let usage_ratio = zero_div(usage, total);
   (avg_freq as u32, usage_ratio as f32)
+}
+
+fn calc_freq(item: CFDictionaryRef, freqs: &[u32]) -> (u32, f32) {
+  let items = cfio_get_residencies(item); // (ns, freq)
+  calc_freq_from_residencies(&items, freqs)
 }
 
 fn calc_freq_final(items: &[(u32, f32)], freqs: &[u32]) -> (u32, f32) {
@@ -332,6 +340,37 @@ impl Sampler {
 
 #[cfg(test)]
 mod tests {
+  use super::calc_freq_from_residencies;
+
+  #[test]
+  fn calc_freq_returns_raw_usage_ratio() {
+    let items = vec![
+      ("IDLE".to_string(), 50),
+      ("F1".to_string(), 25),
+      ("F2".to_string(), 15),
+      ("F3".to_string(), 10),
+    ];
+    let (freq, usage) = calc_freq_from_residencies(&items, &[1000, 2000, 3000]);
+
+    assert_eq!(freq, 1700);
+    assert_eq!(usage, 0.5);
+  }
+
+  #[test]
+  fn calc_freq_with_mismatched_states_matches_legacy_mapping() {
+    let items = vec![
+      ("IDLE".to_string(), 50),
+      ("S1".to_string(), 0),
+      ("S2".to_string(), 0),
+      ("S3".to_string(), 0),
+      ("S4".to_string(), 50),
+    ];
+    let (freq, usage) = calc_freq_from_residencies(&items, &[1000, 2000]);
+
+    assert_eq!(freq, 0);
+    assert!((usage - 0.5f32).abs() < 1e-6f32);
+  }
+
   #[test]
   fn ultra_cpu_channel_matching() {
     // On Ultra chips (M1/M2/M3 Ultra) IOReport CPU Stats channels are prefixed "DIE_N_".

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -31,10 +31,10 @@ pub struct MemMetrics {
 pub struct Metrics {
   pub temp: TempMetrics,
   pub memory: MemMetrics,
-  pub ecpu_usage: (u32, f32), // freq, percent_from_max
-  pub pcpu_usage: (u32, f32), // freq, percent_from_max
+  pub ecpu_usage: (u32, f32), // freq MHz, usage ratio
+  pub pcpu_usage: (u32, f32), // freq MHz, usage ratio
   pub cpu_usage_pct: f32,     // combined ecpu+pcpu usage, weighted by core count
-  pub gpu_usage: (u32, f32),  // freq, percent_from_max
+  pub gpu_usage: (u32, f32),  // freq MHz, usage ratio
   pub cpu_power: f32,         // Watts
   pub gpu_power: f32,         // Watts
   pub ane_power: f32,         // Watts
@@ -74,11 +74,7 @@ fn calc_freq(item: CFDictionaryRef, freqs: &[u32]) -> (u32, f32) {
   }
 
   let usage_ratio = zero_div(usage, total);
-  let min_freq = *freqs.first().unwrap() as f64;
-  let max_freq = *freqs.last().unwrap() as f64;
-  let from_max = (avg_freq.max(min_freq) * usage_ratio) / max_freq;
-
-  (avg_freq as u32, from_max as f32)
+  (avg_freq as u32, usage_ratio as f32)
 }
 
 fn calc_freq_final(items: &[(u32, f32)], freqs: &[u32]) -> (u32, f32) {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -89,11 +89,17 @@ fn calc_freq(item: CFDictionaryRef, freqs: &[u32]) -> (u32, f32) {
   calc_freq_from_residencies(&items, freqs)
 }
 
-fn calc_cluster_usage(items: &[(u32, f32)]) -> (u32, f32) {
-  let avg_freq = zero_div(items.iter().map(|x| x.0 as f32).sum(), items.len() as f32);
-  let avg_perc = zero_div(items.iter().map(|x| x.1).sum(), items.len() as f32);
+fn calc_cluster_usage_at_peak_freq(items: &[(u32, f32)]) -> (u32, f32) {
+  let peak_freq = items.iter().filter(|x| x.1 > 0.0).map(|x| x.0).max().unwrap_or(0);
+  if peak_freq == 0 {
+    return (0, 0.0);
+  }
 
-  (avg_freq as u32, avg_perc)
+  let peak_freq = peak_freq as f32;
+  let usage =
+    zero_div(items.iter().map(|x| x.1 * x.0 as f32 / peak_freq).sum(), items.len() as f32);
+
+  (peak_freq as u32, usage)
 }
 
 fn init_smc() -> WithError<(SMC, Vec<String>, Vec<String>)> {
@@ -300,8 +306,8 @@ impl Sampler {
 
       // Filter dead/disabled cores (e.g. M5 Max MCPU0 cluster is all-DOWN)
       ecpu_usages.retain(|&(_, pct)| pct > 0.0);
-      rs.ecpu_usage = calc_cluster_usage(&ecpu_usages);
-      rs.pcpu_usage = calc_cluster_usage(&pcpu_usages);
+      rs.ecpu_usage = calc_cluster_usage_at_peak_freq(&ecpu_usages);
+      rs.pcpu_usage = calc_cluster_usage_at_peak_freq(&pcpu_usages);
       results.push(rs);
     }
 
@@ -343,7 +349,7 @@ impl Sampler {
 
 #[cfg(test)]
 mod tests {
-  use super::{calc_cluster_usage, calc_freq_from_residencies};
+  use super::{calc_cluster_usage_at_peak_freq, calc_freq_from_residencies};
 
   #[test]
   fn calc_freq_returns_raw_usage_ratio() {
@@ -383,11 +389,31 @@ mod tests {
   }
 
   #[test]
-  fn calc_cluster_usage_preserves_idle_frequency() {
-    let (freq, usage) = calc_cluster_usage(&[(0, 0.0), (0, 0.0)]);
+  fn calc_cluster_usage_at_peak_freq_preserves_idle_frequency() {
+    let (freq, usage) = calc_cluster_usage_at_peak_freq(&[(0, 0.0), (0, 0.0)]);
 
     assert_eq!(freq, 0);
     assert_eq!(usage, 0.0);
+  }
+
+  #[test]
+  fn calc_cluster_usage_at_peak_freq_scales_usage_to_peak_frequency() {
+    let items = [
+      (4500, 1.0),
+      (1000, 0.3),
+      (0, 0.0),
+      (0, 0.0),
+      (0, 0.0),
+      (0, 0.0),
+      (0, 0.0),
+      (0, 0.0),
+      (0, 0.0),
+      (0, 0.0),
+    ];
+    let (freq, usage) = calc_cluster_usage_at_peak_freq(&items);
+
+    assert_eq!(freq, 4500);
+    assert!((usage - 0.10666).abs() < 1e-5);
   }
 
   #[test]


### PR DESCRIPTION
This PR ports the frequency/usage calculation fixes from #59.


# Summary

It changes how usage tuples are calculated:

- sampled CPU/GPU usage is now based on IOReport active residency ratio, not scaled by frequency;
- CPU cluster frequency is reported as the highest active core frequency in the sample;
- CPU cluster usage is normalized to that reported peak active frequency;
- idle CPU clusters now remain `0 MHz / 0%` instead of being forced to the minimum DVFS frequency.

The JSON shape is unchanged: `ecpu_usage`, `pcpu_usage`, and `gpu_usage` are still `[freq_mhz, usage]`.

# Why

In the previous implementation, [`calc_freq`](https://github.com/vladkens/macmon/blob/25e6f3d/src/metrics.rs#L53-L77) scaled usage by `avg_freq / max_freq`, and the result was exposed through fields such as [`pcpu_usage`](https://github.com/vladkens/macmon/blob/25e6f3d/src/metrics.rs#L270-L287):

```text
usage = active_residency / total_residency * avg_freq / max_freq
```

That mixes occupancy with frequency. Under Low Power Mode, thermal limits, or any workload where frequency and occupancy diverge, a fully busy core can look partially idle just because it is not running at the theoretical maximum frequency.

[Issue #46](https://github.com/vladkens/macmon/issues/46) correctly pointed out that the reported value was misleading. The problem was likely not that one CPU cluster was being dropped, but that the metric itself under-reported occupancy by folding frequency into usage.

This PR first computes usage from residency, then aggregates CPU cluster values as a compact "effective load at shown active frequency" summary.

# Examples

All examples use a 10-core P-cluster with `min_freq = 1250 MHz` and `max_freq = 4500 MHz`.

## All idle

```text
  10 cores: 0% @ 0 MHz
```

```text
Old TUI: P-CPU 0.0% @ 1250 MHz
New TUI: P-CPU 0.0% @ 0 MHz
```

Why: if the cluster has no active residency in the sample window, there is no observed active frequency to report.

## One active core

```text
  1 core: 100% @ 3600 MHz
  9 cores: 0% @ 0 MHz
```

```text
Old TUI: P-CPU 8.0% @ 1250 MHz (freq = max(3600 / 10, 1250))
New TUI: P-CPU 10.0% @ 3600 MHz
```

Why: one of ten cores is fully occupied, and the active work is running at 3600 MHz.

## One active core, idle cores still report frequency

```text
  1 core: 100% @ 3600 MHz
  4 cores: 0% @ 3600 MHz
  5 cores: 0% @ 0 MHz
```

```text
Old TUI: P-CPU 8.0% @ 1800 MHz
New TUI: P-CPU 10.0% @ 3600 MHz
```

Why: idle cores may still carry a reported frequency, but the cluster summary should describe active work.

## One peak core plus low-frequency active cores

```text
  1 core: 100% @ 3600 MHz
  4 cores: 80% @ 1000 MHz
  5 cores: 0% @ 0 MHz
```

```text
Old TUI: P-CPU 15.1% @ 1250 MHz (freq = max((3600 + 1000 * 4) / 10, 1250))
New TUI: P-CPU 18.9% @ 3600 MHz
```

Why: the summary keeps the observed peak active frequency visible, while lower-frequency work contributes proportionally less to effective load at that frequency.

## All cores fully active under frequency limits

```text
  10 cores: 100% @ 2500 MHz
```

```text
Old TUI: P-CPU 55.6% @ 2500 MHz
New TUI: P-CPU 100.0% @ 2500 MHz
```

Why: the cluster is fully occupied. A lower frequency caused by thermal or power limits should not make fully busy cores look idle.
