### PR TITLE
Add host option for metrics server

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -132,6 +132,7 @@ You can use the `serve` subcommand to expose metrics over HTTP. This is useful f
 
 ```sh
 macmon serve            # default port 9090, interval 1000ms
+macmon serve --host 127.0.0.1  # listen on localhost only
 macmon serve -p 8080    # custom port
 macmon serve -i 500     # sampling interval 500ms
 macmon serve &          # run in background
@@ -151,6 +152,7 @@ To start `macmon serve` automatically on login and keep it running:
 ```sh
 macmon serve --install              # install and start (default port 9090)
 macmon serve --port 8080 --install  # with custom port
+macmon serve --host 127.0.0.1 --install  # listen on localhost only
 macmon serve --uninstall            # stop and remove
 ```
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,27 @@
 use clap::{CommandFactory, Parser, Subcommand, parser::ValueSource};
 use macmon::{App, Sampler, debug};
 use std::error::Error;
+use std::net::ToSocketAddrs;
 use std::sync::{Arc, RwLock};
 use std::thread;
 
 mod serve;
+
+// Validate by asking the platform resolver for at least one socket address.
+// The original host string is preserved so launchd and serve use the same value
+// the user provided.
+fn validate_host(host: &str) -> Result<String, String> {
+  match (host, 0).to_socket_addrs() {
+    Ok(mut addrs) => {
+      if addrs.next().is_some() {
+        Ok(host.to_string())
+      } else {
+        Err("host must resolve to a socket address".to_string())
+      }
+    }
+    _ => Err("host must resolve to a socket address".to_string()),
+  }
+}
 
 #[derive(Debug, Subcommand)]
 enum Commands {
@@ -22,6 +39,10 @@ enum Commands {
 
   /// Serve metrics over HTTP (JSON at /json, Prometheus at /metrics)
   Serve {
+    /// Host address to listen on
+    #[arg(long, default_value = "0.0.0.0", value_parser = validate_host)]
+    host: String,
+
     /// Port to listen on
     #[arg(short, long, default_value_t = 9090)]
     port: u16,
@@ -80,9 +101,9 @@ fn main() -> Result<(), Box<dyn Error>> {
         }
       }
     }
-    Some(Commands::Serve { port, install, uninstall }) => {
+    Some(Commands::Serve { host, port, install, uninstall }) => {
       if *install || *uninstall {
-        serve::launchd(*port, *install)?;
+        serve::launchd(host, *port, *install)?;
         return Ok(());
       }
       let mut sampler = Sampler::new()?;
@@ -91,9 +112,10 @@ fn main() -> Result<(), Box<dyn Error>> {
 
       let shared_http = Arc::clone(&shared);
       let soc_http = Arc::clone(&soc);
+      let host = host.clone();
       let port = *port;
       thread::spawn(move || {
-        if let Err(e) = serve::run(port, shared_http, soc_http) {
+        if let Err(e) = serve::run(&host, port, shared_http, soc_http) {
           eprintln!("server error: {e}");
         }
       });
@@ -120,4 +142,41 @@ fn main() -> Result<(), Box<dyn Error>> {
   }
 
   Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+  use super::validate_host;
+
+  #[test]
+  fn accepts_resolvable_hosts() {
+    assert!(validate_host("127.0.0.1").is_ok());
+    assert!(validate_host("::1").is_ok());
+    assert!(validate_host("0.0.0.0").is_ok());
+    assert!(validate_host("localhost").is_ok());
+    assert!(validate_host("0").is_ok());
+    assert!(validate_host("127.1").is_ok());
+  }
+
+  #[test]
+  fn rejects_invalid_hostnames() {
+    assert!(validate_host("").is_err());
+    assert!(validate_host("example..com").is_err());
+    assert!(validate_host("example com").is_err());
+    assert!(validate_host("example.com:9090").is_err());
+  }
+
+  #[test]
+  fn rejects_unresolvable_dns_hostnames() {
+    assert!(validate_host("example.invalid").is_err());
+  }
+
+  #[test]
+  fn rejects_xml_metacharacters() {
+    assert!(validate_host("<example>").is_err());
+    assert!(validate_host("example>host").is_err());
+    assert!(validate_host("example&host").is_err());
+    assert!(validate_host(r#""example""#).is_err());
+    assert!(validate_host("example'host").is_err());
+  }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,27 +1,10 @@
 use clap::{CommandFactory, Parser, Subcommand, parser::ValueSource};
 use macmon::{App, Sampler, debug};
 use std::error::Error;
-use std::net::ToSocketAddrs;
 use std::sync::{Arc, RwLock};
 use std::thread;
 
 mod serve;
-
-// Validate by asking the platform resolver for at least one socket address.
-// The original host string is preserved so launchd and serve use the same value
-// the user provided.
-fn validate_host(host: &str) -> Result<String, String> {
-  match (host, 0).to_socket_addrs() {
-    Ok(mut addrs) => {
-      if addrs.next().is_some() {
-        Ok(host.to_string())
-      } else {
-        Err("host must resolve to a socket address".to_string())
-      }
-    }
-    _ => Err("host must resolve to a socket address".to_string()),
-  }
-}
 
 #[derive(Debug, Subcommand)]
 enum Commands {
@@ -40,7 +23,7 @@ enum Commands {
   /// Serve metrics over HTTP (JSON at /json, Prometheus at /metrics)
   Serve {
     /// Host address to listen on
-    #[arg(long, default_value = "0.0.0.0", value_parser = validate_host)]
+    #[arg(long, default_value = "0.0.0.0")]
     host: String,
 
     /// Port to listen on
@@ -142,41 +125,4 @@ fn main() -> Result<(), Box<dyn Error>> {
   }
 
   Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-  use super::validate_host;
-
-  #[test]
-  fn accepts_resolvable_hosts() {
-    assert!(validate_host("127.0.0.1").is_ok());
-    assert!(validate_host("::1").is_ok());
-    assert!(validate_host("0.0.0.0").is_ok());
-    assert!(validate_host("localhost").is_ok());
-    assert!(validate_host("0").is_ok());
-    assert!(validate_host("127.1").is_ok());
-  }
-
-  #[test]
-  fn rejects_invalid_hostnames() {
-    assert!(validate_host("").is_err());
-    assert!(validate_host("example..com").is_err());
-    assert!(validate_host("example com").is_err());
-    assert!(validate_host("example.com:9090").is_err());
-  }
-
-  #[test]
-  fn rejects_unresolvable_dns_hostnames() {
-    assert!(validate_host("example.invalid").is_err());
-  }
-
-  #[test]
-  fn rejects_xml_metacharacters() {
-    assert!(validate_host("<example>").is_err());
-    assert!(validate_host("example>host").is_err());
-    assert!(validate_host("example&host").is_err());
-    assert!(validate_host(r#""example""#).is_err());
-    assert!(validate_host("example'host").is_err());
-  }
 }

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -87,6 +87,15 @@ fn serve_url(host: &str, port: u16) -> String {
   format!("http://{host}:{port}")
 }
 
+fn escape_xml(value: &str) -> String {
+  value
+    .replace('&', "&amp;")
+    .replace('<', "&lt;")
+    .replace('>', "&gt;")
+    .replace('"', "&quot;")
+    .replace('\'', "&apos;")
+}
+
 fn handle_conn(mut stream: TcpStream, shared: SharedMetrics, soc: Arc<SocInfo>) {
   let path = match read_path(&mut stream) {
     Some(p) => p,
@@ -141,6 +150,8 @@ pub fn launchd(host: &str, port: u16, install: bool) -> Result<(), Box<dyn std::
 
   let bin = std::env::current_exe()?;
   let bin = bin.to_string_lossy();
+  let bin = escape_xml(&bin);
+  let host_xml = escape_xml(host);
   let plist = format!(
     r#"<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -153,7 +164,7 @@ pub fn launchd(host: &str, port: u16, install: bool) -> Result<(), Box<dyn std::
     <string>{bin}</string>
     <string>serve</string>
     <string>--host</string>
-    <string>{host}</string>
+    <string>{host_xml}</string>
     <string>--port</string>
     <string>{port}</string>
   </array>
@@ -207,7 +218,7 @@ pub fn run(
 
 #[cfg(test)]
 mod tests {
-  use super::serve_url;
+  use super::{escape_xml, serve_url};
 
   #[test]
   fn formats_serving_urls() {
@@ -215,5 +226,10 @@ mod tests {
     assert_eq!(serve_url("0.0.0.0", 9090), "http://localhost:9090");
     assert_eq!(serve_url("::", 9090), "http://localhost:9090");
     assert_eq!(serve_url("::1", 9090), "http://[::1]:9090");
+  }
+
+  #[test]
+  fn escapes_xml_values() {
+    assert_eq!(escape_xml(r#"<host>&"'host"#), "&lt;host&gt;&amp;&quot;&apos;host");
   }
 }

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -76,6 +76,17 @@ fn write_response(stream: &mut TcpStream, status: u16, content_type: &str, body:
   );
 }
 
+fn serve_url(host: &str, port: u16) -> String {
+  let host = if matches!(host, "0.0.0.0" | "::") { "localhost" } else { host };
+  let host = if host.contains(':') && !host.starts_with('[') {
+    format!("[{host}]")
+  } else {
+    host.to_string()
+  };
+
+  format!("http://{host}:{port}")
+}
+
 fn handle_conn(mut stream: TcpStream, shared: SharedMetrics, soc: Arc<SocInfo>) {
   let path = match read_path(&mut stream) {
     Some(p) => p,
@@ -113,7 +124,7 @@ fn handle_conn(mut stream: TcpStream, shared: SharedMetrics, soc: Arc<SocInfo>) 
   }
 }
 
-pub fn launchd(port: u16, install: bool) -> Result<(), Box<dyn std::error::Error>> {
+pub fn launchd(host: &str, port: u16, install: bool) -> Result<(), Box<dyn std::error::Error>> {
   let home = std::env::var("HOME")?;
   let plist_path = format!("{home}/Library/LaunchAgents/com.macmon.plist");
 
@@ -141,6 +152,8 @@ pub fn launchd(port: u16, install: bool) -> Result<(), Box<dyn std::error::Error
   <array>
     <string>{bin}</string>
     <string>serve</string>
+    <string>--host</string>
+    <string>{host}</string>
     <string>--port</string>
     <string>{port}</string>
   </array>
@@ -166,18 +179,19 @@ pub fn launchd(port: u16, install: bool) -> Result<(), Box<dyn std::error::Error
   std::fs::write(&plist_path, plist)?;
   std::process::Command::new("launchctl").args(["load", &plist_path]).status()?;
   eprintln!("macmon service installed: {plist_path}");
-  eprintln!("serving on http://localhost:{port}");
+  eprintln!("serving on {}", serve_url(host, port));
 
   Ok(())
 }
 
 pub fn run(
+  host: &str,
   port: u16,
   shared: SharedMetrics,
   soc: Arc<SocInfo>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-  let listener = TcpListener::bind(format!("0.0.0.0:{port}"))?;
-  eprintln!("macmon serving on http://localhost:{port}");
+  let listener = TcpListener::bind((host, port))?;
+  eprintln!("macmon serving on {}", serve_url(host, port));
   eprintln!("  GET /json    → JSON metrics");
   eprintln!("  GET /metrics → Prometheus format");
 
@@ -189,4 +203,17 @@ pub fn run(
   }
 
   Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+  use super::serve_url;
+
+  #[test]
+  fn formats_serving_urls() {
+    assert_eq!(serve_url("127.0.0.1", 9090), "http://127.0.0.1:9090");
+    assert_eq!(serve_url("0.0.0.0", 9090), "http://localhost:9090");
+    assert_eq!(serve_url("::", 9090), "http://localhost:9090");
+    assert_eq!(serve_url("::1", 9090), "http://[::1]:9090");
+  }
 }


### PR DESCRIPTION
Allow macmon serve to bind to a specific host address while preserving the existing 0.0.0.0 default.  This allows restricting access to localhost only, tailscale, etc.

Persist the selected host when installing the launchd service and document localhost-only examples.