### PR TITLE
feat: add fan speed metrics

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -112,6 +112,13 @@ This will collect 10 samples with an update interval of 500 milliseconds.
     "swap_total": 4294967296,         // Bytes
     "swap_usage": 2602434560          // Bytes
   },
+  "fans": [
+    {
+      "name": "Fan0",
+      "key": "F0Ac",                  // SMC fan key
+      "rpm": 1234                     // Revolutions per minute
+    }
+  ],
   "ecpu_usage": [1181, 0.082656614],  // (Frequency MHz, Usage %)
   "pcpu_usage": [1974, 0.015181795],  // (Frequency MHz, Usage %)
   "cpu_usage_pct": 0.036854,          // Combined CPU usage (weighted by core count, 0–1)
@@ -204,6 +211,10 @@ macmon_cpu_temp_celsius{chip="Apple M3 Pro"} 47.3
 # HELP macmon_cpu_power_watts CPU power consumption in Watts
 # TYPE macmon_cpu_power_watts gauge
 macmon_cpu_power_watts{chip="Apple M3 Pro"} 8.42
+
+# HELP macmon_fan_speed_rpm Fan speed in revolutions per minute
+# TYPE macmon_fan_speed_rpm gauge
+macmon_fan_speed_rpm{chip="Apple M3 Pro",fan="Fan0",key="F0Ac"} 1234
 
 # HELP macmon_cpu_usage_ratio Combined CPU utilization (0–1), weighted by core count
 # TYPE macmon_cpu_usage_ratio gauge

--- a/readme.md
+++ b/readme.md
@@ -114,9 +114,8 @@ This will collect 10 samples with an update interval of 500 milliseconds.
   },
   "fans": [
     {
-      "name": "Fan0",
-      "key": "F0Ac",                  // SMC fan key
-      "rpm": 1234                     // Revolutions per minute
+      "rpm": 1234,                    // Revolutions per minute
+      "max_rpm": 5200                 // Maximum RPM, if available
     }
   ],
   "ecpu_usage": [1181, 0.082656614],  // (Frequency MHz, Usage %)
@@ -214,7 +213,7 @@ macmon_cpu_power_watts{chip="Apple M3 Pro"} 8.42
 
 # HELP macmon_fan_speed_rpm Fan speed in revolutions per minute
 # TYPE macmon_fan_speed_rpm gauge
-macmon_fan_speed_rpm{chip="Apple M3 Pro",fan="Fan0",key="F0Ac"} 1234
+macmon_fan_speed_rpm{chip="Apple M3 Pro",fan="0"} 1234
 
 # HELP macmon_cpu_usage_ratio Combined CPU utilization (0–1), weighted by core count
 # TYPE macmon_cpu_usage_ratio gauge

--- a/src/app.rs
+++ b/src/app.rs
@@ -10,7 +10,7 @@ use ratatui::crossterm::{
 use ratatui::{prelude::*, widgets::*};
 
 use crate::config::{Config, ViewType};
-use crate::metrics::{Metrics, Sampler, zero_div};
+use crate::metrics::{FanMetric, Metrics, Sampler, zero_div};
 use crate::{metrics::MemMetrics, sources::SocInfo};
 
 type WithError<T> = Result<T, Box<dyn std::error::Error>>;
@@ -142,6 +142,26 @@ impl TempStore {
   }
 }
 
+#[derive(Debug, Default)]
+struct FanStore {
+  items: Vec<FanMetric>,
+}
+
+impl FanStore {
+  fn push(&mut self, value: Vec<FanMetric>) {
+    self.items = value;
+  }
+
+  fn label(&self) -> String {
+    self
+      .items
+      .iter()
+      .map(|fan| format!("{} {}RPM", fan.name, fan.rpm))
+      .collect::<Vec<_>>()
+      .join(" ")
+  }
+}
+
 fn bar_set() -> symbols::bar::Set<'static> {
   match std::env::var("TERM_PROGRAM").as_deref() {
     Ok("Apple_Terminal") => symbols::bar::THREE_LEVELS,
@@ -244,6 +264,7 @@ pub struct App {
 
   cpu_temp: TempStore,
   gpu_temp: TempStore,
+  fans: FanStore,
 
   ecpu_freq: FreqStore,
   pcpu_freq: FreqStore,
@@ -269,6 +290,7 @@ impl App {
 
     self.cpu_temp.push(data.temp.cpu_temp_avg);
     self.gpu_temp.push(data.temp.gpu_temp_avg);
+    self.fans.push(data.fans);
 
     self.mem.push(data.memory);
   }
@@ -420,14 +442,21 @@ impl App {
       self.all_power.top_value, self.all_power.avg_value, self.all_power.max_value,
     );
 
-    // Show label only if sensor is available
-    let label_r = if self.sys_power.top_value > 0.0 {
-      format!(
+    // Show labels only if sensors are available
+    let fan_label = self.fans.label();
+    let sys_label = if self.sys_power.top_value > 0.0 {
+      Some(format!(
         "Total {:.2}W ({:.2}, {:.2})",
         self.sys_power.top_value, self.sys_power.avg_value, self.sys_power.max_value
-      )
+      ))
     } else {
-      "".to_string()
+      None
+    };
+    let label_r = match (!fan_label.is_empty(), sys_label) {
+      (true, Some(sys_label)) => format!("{fan_label} | {sys_label}"),
+      (true, None) => fan_label,
+      (false, Some(sys_label)) => sys_label,
+      (false, None) => "".to_string(),
     };
 
     let block = self.title_block(&label_l, &label_r);

--- a/src/app.rs
+++ b/src/app.rs
@@ -153,12 +153,14 @@ impl FanStore {
   }
 
   fn label(&self) -> String {
-    self
-      .items
-      .iter()
-      .map(|fan| format!("{} {}RPM", fan.name, fan.rpm))
-      .collect::<Vec<_>>()
-      .join(" ")
+    match self.items.as_slice() {
+      [] => "".to_string(),
+      [fan] => format!("Fan {} RPM", fan.rpm),
+      fans => {
+        let values = fans.iter().map(|fan| fan.rpm.to_string()).collect::<Vec<_>>().join("/");
+        format!("Fans {values} RPM")
+      }
+    }
   }
 }
 

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -112,6 +112,27 @@ pub fn print_debug() -> WithError<()> {
 
   println!(); // close previous line
 
+  print_divider("SMC fan sensors");
+  for key in &keys {
+    let is_fan_key = key.len() == 4 && key.starts_with('F');
+    let is_fan_id_key = key.len() == 4
+      && key.starts_with('F')
+      && key.as_bytes()[1].is_ascii_digit()
+      && key.ends_with("ID");
+    if !(is_fan_key || is_fan_id_key) {
+      continue;
+    }
+
+    let ki = smc.read_key_info(key)?;
+    let val = smc.read_val(key);
+    if val.is_err() {
+      continue;
+    }
+
+    let val = val.unwrap();
+    println!("{} type={} size={} bytes={:?}", key, val.unit, ki.data_size, val.data);
+  }
+
   print_divider("IOHID");
   let hid = IOHIDSensors::new()?;
   for (key, val) in hid.get_metrics() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,5 +12,5 @@ pub mod sources;
 // Re-export commonly used types
 pub use app::App;
 pub use config::{Config, ViewType};
-pub use metrics::{MemMetrics, Metrics, Sampler, TempMetrics, zero_div};
+pub use metrics::{FanMetric, MemMetrics, Metrics, Sampler, TempMetrics, zero_div};
 pub use sources::SocInfo;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,4 +1,5 @@
 use core_foundation::dictionary::CFDictionaryRef;
+
 use serde::Serialize;
 
 use crate::sources::{
@@ -29,9 +30,15 @@ pub struct MemMetrics {
 
 #[derive(Debug, Default, Serialize)]
 pub struct FanMetric {
-  pub name: String,
-  pub key: String,
   pub rpm: u32,
+  pub max_rpm: Option<u32>,
+}
+
+struct SmcSensors {
+  smc: SMC,
+  cpu_keys: Vec<String>,
+  gpu_keys: Vec<String>,
+  fan_keys: Vec<String>,
 }
 
 #[derive(Debug, Default, Serialize)]
@@ -64,30 +71,11 @@ fn is_valid_temp(val: f32) -> bool {
 }
 
 fn is_valid_fan_rpm(val: f32) -> bool {
-  val >= 0.0 && val <= 100_000.0
+  (0.0..=100_000.0).contains(&val)
 }
 
 fn fan_rpm_value(val: f32) -> Option<u32> {
   if is_valid_fan_rpm(val) { Some(val.trunc() as u32) } else { None }
-}
-
-fn fan_name_from_smc_key(key: &str) -> String {
-  let Some(idx) = key.strip_prefix('F').and_then(|s| s.chars().next()).and_then(|c| c.to_digit(10))
-  else {
-    return key.to_string();
-  };
-  format!("Fan{}", idx)
-}
-
-fn fan_name_from_smc_id(data: &[u8]) -> Option<String> {
-  if data.len() <= 4 {
-    return None;
-  }
-
-  let name = data[4..].iter().copied().take_while(|b| *b != 0).collect::<Vec<u8>>();
-  let name = String::from_utf8(name).ok()?;
-  let name = name.trim();
-  if name.is_empty() { None } else { Some(name.to_string()) }
 }
 
 fn smc_numeric_value(data: &[u8], unit: &str) -> Option<f32> {
@@ -99,6 +87,12 @@ fn smc_numeric_value(data: &[u8], unit: &str) -> Option<f32> {
     "ui32" if data.len() >= 4 => Some(u32::from_be_bytes(data[0..4].try_into().ok()?) as f32),
     _ => None,
   }
+}
+
+fn read_smc_numeric_u32(smc: &mut SMC, key: &str) -> Option<u32> {
+  let val = smc.read_val(key).ok()?;
+  let val = smc_numeric_value(&val.data, &val.unit)?;
+  fan_rpm_value(val)
 }
 
 fn calc_freq(item: CFDictionaryRef, freqs: &[u32]) -> (u32, f32) {
@@ -135,7 +129,7 @@ fn calc_freq_final(items: &[(u32, f32)], freqs: &[u32]) -> (u32, f32) {
   (avg_freq.max(min_freq) as u32, avg_perc)
 }
 
-fn init_smc() -> WithError<(SMC, Vec<String>, Vec<String>, Vec<String>)> {
+fn init_smc() -> WithError<SmcSensors> {
   let mut smc = SMC::new()?;
   const FLOAT_TYPE: u32 = 1718383648; // FourCC: "flt "
 
@@ -177,9 +171,12 @@ fn init_smc() -> WithError<(SMC, Vec<String>, Vec<String>, Vec<String>)> {
     }
   }
 
+  // Sort first so fan order is stable and any duplicate keys become adjacent for dedup().
   fan_sensors.sort();
+  fan_sensors.dedup();
+
   // println!("{} {}", cpu_sensors.len(), gpu_sensors.len());
-  Ok((smc, cpu_sensors, gpu_sensors, fan_sensors))
+  Ok(SmcSensors { smc, cpu_keys: cpu_sensors, gpu_keys: gpu_sensors, fan_keys: fan_sensors })
 }
 
 // MARK: Sampler
@@ -206,9 +203,17 @@ impl Sampler {
     let soc = SocInfo::new()?;
     let ior = IOReport::new(channels)?;
     let hid = IOHIDSensors::new()?;
-    let (smc, smc_cpu_keys, smc_gpu_keys, smc_fan_keys) = init_smc()?;
+    let smc_sensors = init_smc()?;
 
-    Ok(Sampler { soc, ior, hid, smc, smc_cpu_keys, smc_gpu_keys, smc_fan_keys })
+    Ok(Sampler {
+      soc,
+      ior,
+      hid,
+      smc: smc_sensors.smc,
+      smc_cpu_keys: smc_sensors.cpu_keys,
+      smc_gpu_keys: smc_sensors.gpu_keys,
+      smc_fan_keys: smc_sensors.fan_keys,
+    })
   }
 
   fn get_temp_smc(&mut self) -> WithError<TempMetrics> {
@@ -275,23 +280,19 @@ impl Sampler {
     }
   }
 
-  fn get_fans(&mut self) -> WithError<Vec<FanMetric>> {
+  fn get_fans(&mut self) -> Vec<FanMetric> {
     let mut fans = Vec::new();
     for key in &self.smc_fan_keys {
-      let val = self.smc.read_val(key)?;
-      let Some(rpm) = smc_numeric_value(&val.data, &val.unit) else {
-        continue;
+      let Some(rpm) = read_smc_numeric_u32(&mut self.smc, key) else { continue };
+      let max_rpm = match key.strip_suffix("Ac") {
+        Some(prefix) => {
+          read_smc_numeric_u32(&mut self.smc, &format!("{prefix}Mx")).filter(|rpm| *rpm > 0)
+        }
+        None => None,
       };
-      if let Some(rpm) = fan_rpm_value(rpm) {
-        let name = key
-          .get(0..2)
-          .and_then(|prefix| self.smc.read_val(&format!("{prefix}ID")).ok())
-          .and_then(|val| fan_name_from_smc_id(&val.data))
-          .unwrap_or_else(|| fan_name_from_smc_key(key));
-        fans.push(FanMetric { name, key: key.clone(), rpm });
-      }
+      fans.push(FanMetric { rpm, max_rpm });
     }
-    Ok(fans)
+    fans
   }
 
   fn get_mem(&mut self) -> WithError<MemMetrics> {
@@ -392,7 +393,7 @@ impl Sampler {
 
     rs.memory = self.get_mem()?;
     rs.temp = self.get_temp()?;
-    rs.fans = self.get_fans()?;
+    rs.fans = self.get_fans();
 
     rs.sys_power = match self.get_sys_power() {
       Ok(val) => val.max(rs.all_power),
@@ -410,7 +411,7 @@ impl Sampler {
 
 #[cfg(test)]
 mod tests {
-  use super::{fan_name_from_smc_id, fan_name_from_smc_key, fan_rpm_value, smc_numeric_value};
+  use super::{fan_rpm_value, smc_numeric_value};
 
   #[test]
   fn parse_smc_numeric_values() {
@@ -425,20 +426,6 @@ mod tests {
     assert_eq!(fan_rpm_value(1234.9), Some(1234));
     assert_eq!(fan_rpm_value(0.0), Some(0));
     assert_eq!(fan_rpm_value(-1.0), None);
-  }
-
-  #[test]
-  fn derive_fan_names_from_smc_keys() {
-    assert_eq!(fan_name_from_smc_key("F0Ac"), "Fan0");
-    assert_eq!(fan_name_from_smc_key("F1Ac"), "Fan1");
-    assert_eq!(fan_name_from_smc_key("FRmp"), "FRmp");
-  }
-
-  #[test]
-  fn derive_fan_names_from_smc_id() {
-    assert_eq!(fan_name_from_smc_id(b"\0\0\0\0Left side\0\0"), Some("Left side".into()));
-    assert_eq!(fan_name_from_smc_id(b"\0\0\0\0Exhaust\0\0"), Some("Exhaust".into()));
-    assert_eq!(fan_name_from_smc_id(b"\0\0\0\0"), None);
   }
 
   #[test]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -28,9 +28,17 @@ pub struct MemMetrics {
 }
 
 #[derive(Debug, Default, Serialize)]
+pub struct FanMetric {
+  pub name: String,
+  pub key: String,
+  pub rpm: u32,
+}
+
+#[derive(Debug, Default, Serialize)]
 pub struct Metrics {
   pub temp: TempMetrics,
   pub memory: MemMetrics,
+  pub fans: Vec<FanMetric>,
   pub ecpu_usage: (u32, f32), // freq, percent_from_max
   pub pcpu_usage: (u32, f32), // freq, percent_from_max
   pub cpu_usage_pct: f32,     // combined ecpu+pcpu usage, weighted by core count
@@ -53,6 +61,44 @@ pub fn zero_div<T: core::ops::Div<Output = T> + Default + PartialEq>(a: T, b: T)
 
 fn is_valid_temp(val: f32) -> bool {
   val > 0.0 && val <= 150.0
+}
+
+fn is_valid_fan_rpm(val: f32) -> bool {
+  val >= 0.0 && val <= 100_000.0
+}
+
+fn fan_rpm_value(val: f32) -> Option<u32> {
+  if is_valid_fan_rpm(val) { Some(val.trunc() as u32) } else { None }
+}
+
+fn fan_name_from_smc_key(key: &str) -> String {
+  let Some(idx) = key.strip_prefix('F').and_then(|s| s.chars().next()).and_then(|c| c.to_digit(10))
+  else {
+    return key.to_string();
+  };
+  format!("Fan{}", idx)
+}
+
+fn fan_name_from_smc_id(data: &[u8]) -> Option<String> {
+  if data.len() <= 4 {
+    return None;
+  }
+
+  let name = data[4..].iter().copied().take_while(|b| *b != 0).collect::<Vec<u8>>();
+  let name = String::from_utf8(name).ok()?;
+  let name = name.trim();
+  if name.is_empty() { None } else { Some(name.to_string()) }
+}
+
+fn smc_numeric_value(data: &[u8], unit: &str) -> Option<f32> {
+  match unit {
+    "flt " if data.len() == 4 => Some(f32::from_le_bytes(data.try_into().ok()?)),
+    "fpe2" if data.len() >= 2 => Some(((data[0] as u16) << 6 | ((data[1] as u16) >> 2)) as f32),
+    "ui8 " if !data.is_empty() => Some(data[0] as f32),
+    "ui16" if data.len() >= 2 => Some(u16::from_be_bytes(data[0..2].try_into().ok()?) as f32),
+    "ui32" if data.len() >= 4 => Some(u32::from_be_bytes(data[0..4].try_into().ok()?) as f32),
+    _ => None,
+  }
 }
 
 fn calc_freq(item: CFDictionaryRef, freqs: &[u32]) -> (u32, f32) {
@@ -89,12 +135,13 @@ fn calc_freq_final(items: &[(u32, f32)], freqs: &[u32]) -> (u32, f32) {
   (avg_freq.max(min_freq) as u32, avg_perc)
 }
 
-fn init_smc() -> WithError<(SMC, Vec<String>, Vec<String>)> {
+fn init_smc() -> WithError<(SMC, Vec<String>, Vec<String>, Vec<String>)> {
   let mut smc = SMC::new()?;
   const FLOAT_TYPE: u32 = 1718383648; // FourCC: "flt "
 
   let mut cpu_sensors = Vec::new();
   let mut gpu_sensors = Vec::new();
+  let mut fan_sensors = Vec::new();
 
   let names = smc.read_all_keys().unwrap_or(vec![]);
   for name in &names {
@@ -102,6 +149,11 @@ fn init_smc() -> WithError<(SMC, Vec<String>, Vec<String>)> {
       Ok(key) => key,
       Err(_) => continue,
     };
+
+    if name.len() == 4 && name.starts_with('F') && name.ends_with("Ac") {
+      fan_sensors.push(name.clone());
+      continue;
+    }
 
     if key.data_size != 4 || key.data_type != FLOAT_TYPE {
       continue;
@@ -125,8 +177,9 @@ fn init_smc() -> WithError<(SMC, Vec<String>, Vec<String>)> {
     }
   }
 
+  fan_sensors.sort();
   // println!("{} {}", cpu_sensors.len(), gpu_sensors.len());
-  Ok((smc, cpu_sensors, gpu_sensors))
+  Ok((smc, cpu_sensors, gpu_sensors, fan_sensors))
 }
 
 // MARK: Sampler
@@ -138,6 +191,7 @@ pub struct Sampler {
   smc: SMC,
   smc_cpu_keys: Vec<String>,
   smc_gpu_keys: Vec<String>,
+  smc_fan_keys: Vec<String>,
 }
 
 impl Sampler {
@@ -152,9 +206,9 @@ impl Sampler {
     let soc = SocInfo::new()?;
     let ior = IOReport::new(channels)?;
     let hid = IOHIDSensors::new()?;
-    let (smc, smc_cpu_keys, smc_gpu_keys) = init_smc()?;
+    let (smc, smc_cpu_keys, smc_gpu_keys, smc_fan_keys) = init_smc()?;
 
-    Ok(Sampler { soc, ior, hid, smc, smc_cpu_keys, smc_gpu_keys })
+    Ok(Sampler { soc, ior, hid, smc, smc_cpu_keys, smc_gpu_keys, smc_fan_keys })
   }
 
   fn get_temp_smc(&mut self) -> WithError<TempMetrics> {
@@ -219,6 +273,25 @@ impl Sampler {
       true => self.get_temp_smc(),
       false => self.get_temp_hid(),
     }
+  }
+
+  fn get_fans(&mut self) -> WithError<Vec<FanMetric>> {
+    let mut fans = Vec::new();
+    for key in &self.smc_fan_keys {
+      let val = self.smc.read_val(key)?;
+      let Some(rpm) = smc_numeric_value(&val.data, &val.unit) else {
+        continue;
+      };
+      if let Some(rpm) = fan_rpm_value(rpm) {
+        let name = key
+          .get(0..2)
+          .and_then(|prefix| self.smc.read_val(&format!("{prefix}ID")).ok())
+          .and_then(|val| fan_name_from_smc_id(&val.data))
+          .unwrap_or_else(|| fan_name_from_smc_key(key));
+        fans.push(FanMetric { name, key: key.clone(), rpm });
+      }
+    }
+    Ok(fans)
   }
 
   fn get_mem(&mut self) -> WithError<MemMetrics> {
@@ -319,6 +392,7 @@ impl Sampler {
 
     rs.memory = self.get_mem()?;
     rs.temp = self.get_temp()?;
+    rs.fans = self.get_fans()?;
 
     rs.sys_power = match self.get_sys_power() {
       Ok(val) => val.max(rs.all_power),
@@ -336,6 +410,37 @@ impl Sampler {
 
 #[cfg(test)]
 mod tests {
+  use super::{fan_name_from_smc_id, fan_name_from_smc_key, fan_rpm_value, smc_numeric_value};
+
+  #[test]
+  fn parse_smc_numeric_values() {
+    assert_eq!(smc_numeric_value(&42.5f32.to_le_bytes(), "flt "), Some(42.5));
+    assert_eq!(smc_numeric_value(&[0x13, 0x88], "fpe2"), Some(1250.0));
+    assert_eq!(smc_numeric_value(&[0x04, 0xd2], "ui16"), Some(1234.0));
+    assert_eq!(smc_numeric_value(&[0x00, 0x00, 0x04, 0xd2], "ui32"), Some(1234.0));
+  }
+
+  #[test]
+  fn parse_fan_rpm_values() {
+    assert_eq!(fan_rpm_value(1234.9), Some(1234));
+    assert_eq!(fan_rpm_value(0.0), Some(0));
+    assert_eq!(fan_rpm_value(-1.0), None);
+  }
+
+  #[test]
+  fn derive_fan_names_from_smc_keys() {
+    assert_eq!(fan_name_from_smc_key("F0Ac"), "Fan0");
+    assert_eq!(fan_name_from_smc_key("F1Ac"), "Fan1");
+    assert_eq!(fan_name_from_smc_key("FRmp"), "FRmp");
+  }
+
+  #[test]
+  fn derive_fan_names_from_smc_id() {
+    assert_eq!(fan_name_from_smc_id(b"\0\0\0\0Left side\0\0"), Some("Left side".into()));
+    assert_eq!(fan_name_from_smc_id(b"\0\0\0\0Exhaust\0\0"), Some("Exhaust".into()));
+    assert_eq!(fan_name_from_smc_id(b"\0\0\0\0"), None);
+  }
+
   #[test]
   fn ultra_cpu_channel_matching() {
     // On Ultra chips (M1/M2/M3 Ultra) IOReport CPU Stats channels are prefixed "DIE_N_".

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -42,6 +42,14 @@ fn to_prometheus(m: &Metrics, soc: &SocInfo) -> String {
   gauge!(out, "macmon_sys_power_watts", "Total system power consumption in Watts", m.sys_power);
   gauge!(out, "macmon_ram_power_watts", "RAM power consumption in Watts", m.ram_power);
   gauge!(out, "macmon_gpu_ram_power_watts", "GPU RAM power consumption in Watts", m.gpu_ram_power);
+  for fan in &m.fans {
+    let fan_name = &fan.name;
+    let fan_key = &fan.key;
+    out.push_str(&format!(
+      "# HELP macmon_fan_speed_rpm Fan speed in revolutions per minute\n# TYPE macmon_fan_speed_rpm gauge\nmacmon_fan_speed_rpm{{{l},fan=\"{fan_name}\",key=\"{fan_key}\"}} {}\n\n",
+      fan.rpm
+    ));
+  }
   out
 }
 

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -12,12 +12,16 @@ fn to_prometheus(m: &Metrics, soc: &SocInfo) -> String {
   let chip = &soc.chip_name;
   let l = format!(r#"chip="{chip}""#);
 
+  macro_rules! gauge_head {
+    ($out:expr, $name:literal, $help:literal) => {
+      $out.push_str(&format!("# HELP {} {}\n# TYPE {} gauge\n", $name, $help, $name));
+    };
+  }
+
   macro_rules! gauge {
     ($out:expr, $name:literal, $help:literal, $value:expr) => {
-      $out.push_str(&format!(
-        "# HELP {} {}\n# TYPE {} gauge\n{}{{{l}}} {}\n\n",
-        $name, $help, $name, $name, $value
-      ));
+      gauge_head!($out, $name, $help);
+      $out.push_str(&format!("{}{{{l}}} {}\n\n", $name, $value));
     };
   }
 
@@ -42,13 +46,12 @@ fn to_prometheus(m: &Metrics, soc: &SocInfo) -> String {
   gauge!(out, "macmon_sys_power_watts", "Total system power consumption in Watts", m.sys_power);
   gauge!(out, "macmon_ram_power_watts", "RAM power consumption in Watts", m.ram_power);
   gauge!(out, "macmon_gpu_ram_power_watts", "GPU RAM power consumption in Watts", m.gpu_ram_power);
-  for fan in &m.fans {
-    let fan_name = &fan.name;
-    let fan_key = &fan.key;
-    out.push_str(&format!(
-      "# HELP macmon_fan_speed_rpm Fan speed in revolutions per minute\n# TYPE macmon_fan_speed_rpm gauge\nmacmon_fan_speed_rpm{{{l},fan=\"{fan_name}\",key=\"{fan_key}\"}} {}\n\n",
-      fan.rpm
-    ));
+  if !m.fans.is_empty() {
+    gauge_head!(out, "macmon_fan_speed_rpm", "Fan speed in revolutions per minute");
+    for (i, fan) in m.fans.iter().enumerate() {
+      out.push_str(&format!("macmon_fan_speed_rpm{{{l},fan=\"{i}\"}} {}\n", fan.rpm));
+    }
+    out.push('\n');
   }
   out
 }


### PR DESCRIPTION
Implements https://github.com/vladkens/macmon/issues/38.

  Created with Codex. Requires manual review and validation by @vladkens, especially on additional Mac models with multiple fans.

  Summary:
  - Adds fan speed collection from SMC `F*Ac` keys.
  - Adds `fans` to JSON output.
  - Exposes `macmon_fan_speed_rpm` in Prometheus with `fan`/`key` labels.
  - Shows fan RPM in the TUI when available.
  - Extends debug output with SMC fan keys.

  Validation:
  - Tested with reports from Mac mini M1, Mac mini M2 Pro, and Mac mini M4, each exposing one fan via `F0Ac`.
  - `cargo fmt --check`
  - `cargo test`
  - `cargo build`