### PR TITLE
fix: avoid panic in frequency sampler on malformed residency windows

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+## v0.8.3 – unreleased
+
+### Fixes
+
+- Fixed a panic in the frequency sampler when a residency window has no IDLE/DOWN/OFF prefix or is malformed (by @YuriNachos)
+
+---
+
 ## v0.8.2 – 2026-08-04
 
 ### Fixes

--- a/src_lib/metrics.rs
+++ b/src_lib/metrics.rs
@@ -204,15 +204,17 @@ fn read_smc_numeric_u32(smc: &mut SMC, key: &str) -> Option<u32> {
 }
 
 fn calc_freq_from_residencies(items: &[(String, i64)], freqs: &[u32]) -> FreqMetrics {
-  let (len1, len2) = (items.len(), freqs.len());
-  assert!(len1 > len2, "calc_freq invalid data: {len1} vs {len2}"); // todo?
-
   // CPU layouts are [IDLE, frequencies...] or [DOWN, IDLE, frequencies...];
-  // GPU uses OFF before frequency states.
-  let offset = items
-    .iter()
-    .position(|x| x.0 != "IDLE" && x.0 != "DOWN" && x.0 != "OFF")
-    .expect("calc_freq missing active states");
+  // GPU uses OFF before frequency states. A window may also start at the first
+  // active state (no inactive prefix); malformed or all-inactive windows return zeros.
+  let Some(offset) = items.iter().position(|x| x.0 != "IDLE" && x.0 != "DOWN" && x.0 != "OFF")
+  else {
+    return (0, 0.0, 0.0);
+  };
+
+  if items.len() - offset < freqs.len() {
+    return (0, 0.0, 0.0);
+  }
 
   let usage = items.iter().skip(offset).take(freqs.len()).map(|x| x.1 as f64).sum::<f64>();
   let total = items.iter().map(|x| x.1 as f64).sum::<f64>();
@@ -694,6 +696,40 @@ mod tests {
     assert_eq!(frequency, 1000);
     assert!((scaled_ratio - 0.05).abs() < f32::EPSILON);
     assert!((active_ratio - 0.1).abs() < f32::EPSILON);
+  }
+
+  #[test]
+  fn calc_freq_handles_residency_window_without_idle_prefix() {
+    let (frequency, scaled_ratio, active_ratio) = calc_freq_from_residencies(
+      &[("1000 MHz".into(), 100), ("2000 MHz".into(), 50)],
+      &[1000, 2000],
+    );
+
+    assert_eq!(frequency, 1333);
+    assert!((scaled_ratio - 2.0 / 3.0).abs() < f32::EPSILON);
+    assert!((active_ratio - 1.0).abs() < f32::EPSILON);
+  }
+
+  #[test]
+  fn calc_freq_returns_safe_values_for_malformed_residency_window() {
+    let (frequency, scaled_ratio, active_ratio) =
+      calc_freq_from_residencies(&[("1000 MHz".into(), 100)], &[1000, 2000]);
+
+    assert_eq!(frequency, 0);
+    assert_eq!(scaled_ratio, 0.0);
+    assert_eq!(active_ratio, 0.0);
+  }
+
+  #[test]
+  fn calc_freq_returns_safe_values_when_all_states_inactive() {
+    let (frequency, scaled_ratio, active_ratio) = calc_freq_from_residencies(
+      &[("IDLE".into(), 100), ("DOWN".into(), 50), ("OFF".into(), 0)],
+      &[1000, 2000],
+    );
+
+    assert_eq!(frequency, 0);
+    assert_eq!(scaled_ratio, 0.0);
+    assert_eq!(active_ratio, 0.0);
   }
 
   #[test]


### PR DESCRIPTION
Fixes the panic reported when a residency window reaches the frequency sampler without an inactive prefix or is otherwise malformed.

## Root cause

`calc_freq_from_residencies` had two panic paths that fired on real Apple-Silicon residency data:

1. `assert!(len1 > len2, "calc_freq invalid data: {len1} vs {len2}")` — aborted whenever `items.len() <= freqs.len()`.
2. `.expect("calc_freq missing active states")` — aborted when every state in the window was `IDLE`/`DOWN`/`OFF` (no active state found).

Both turned a transient/edge-shaped residency window into a hard crash of the whole monitor.

## Changes

- Removed the `assert!` and the `.expect`. The active-state search now uses `let Some(offset) = … else { return (0, 0.0, 0.0) }`, and a length guard returns the same zero metric when fewer than `freqs.len()` active states remain after the offset.
- A window with no inactive prefix (starts directly at the first active state) is now accepted, matching real CPU layouts.
- Malformed or all-inactive windows return `(0, 0.0, 0.0)` instead of panicking — the monitor stays alive and emits zeros for that sample.

`src_lib/metrics.rs` is the only code change; no `src_app`/TUI/CLI concern is pulled into the lib (`cargo check --lib --no-default-features --locked` stays green).

## Backward compatibility

Behavior is unchanged for every well-formed residency window (the existing `calculates_frequency_over_the_complete_residency_window` and `ultra_cpu_channel_matching` tests are untouched and green). The only observable difference is that inputs which previously **panicked** now yield a zero metric — strictly safer, no regression for valid data across M1–M5.

## Test plan

- [x] `make check` — `cargo fmt --check`, `cargo clippy --all-targets --locked -- -D warnings`, `cargo check --release --bin macmon --locked`, `cargo check --lib --no-default-features --locked` all clean.
- [x] `make test` — 16 lib tests (3 new), 4 app tests, 3 doctests, 0 failed. New cases:
  - `calc_freq_handles_residency_window_without_idle_prefix` — window starting at the first active state resolves (frequency `1333`, scaled `2/3`, active `1.0`).
  - `calc_freq_returns_safe_values_for_malformed_residency_window` — too-few active states → zeros, no panic.
  - `calc_freq_returns_safe_values_when_all_states_inactive` — all `IDLE`/`DOWN`/`OFF` → zeros, no panic.
- [x] Ran an independent adversarial review swarm (logic + regression lenses) against the diff — no blocking findings.

## Notes

Two pre-existing, out-of-scope edges are intentionally **not** fixed here and recorded for a separate follow-up: an empty `freqs` slice would still `.unwrap()` later, and a zero final frequency can yield `inf`/`NaN`. They predate this change and are independent of the panic fixed in this PR.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) — authored by `@YuriNachos`, code written by a `cccc` worker under orchestrator acceptance (gate green + adversarial review swarm clean).
